### PR TITLE
Externalize global variables

### DIFF
--- a/lib/include/hcc_detail/hip_rng.h
+++ b/lib/include/hcc_detail/hip_rng.h
@@ -62,17 +62,17 @@ typedef mtgp32_kernel_params mtgp32_kernel_params_t;
 
 typedef void *hiprngGenerator_t;
 
-hcrngMrg31k3pStream *streams_bufferMrg31k3p = NULL;
-hcrngMrg32k3aStream *streams_bufferMrg32k3a = NULL;
-hcrngLfsr113Stream *streams_bufferLfsr113 = NULL;
-hcrngPhilox432Stream *streams_bufferPhilox432 = NULL;
-hcrngXorwowStream *streams_bufferXorwow = NULL;
+extern hcrngMrg31k3pStream *streams_bufferMrg31k3p;
+extern hcrngMrg32k3aStream *streams_bufferMrg32k3a;
+extern hcrngLfsr113Stream *streams_bufferLfsr113;
+extern hcrngPhilox432Stream *streams_bufferPhilox432;
+extern hcrngXorwowStream *streams_bufferXorwow;
 
-hcrngMrg31k3pStream *streamsMrg31k3p = NULL;
-hcrngMrg32k3aStream *streamsMrg32k3a = NULL;
-hcrngLfsr113Stream *streamsLfsr113 = NULL;
-hcrngPhilox432Stream *streamsPhilox432 = NULL;
-hcrngXorwowStream *streamsXorwow = NULL;
+extern hcrngMrg31k3pStream *streamsMrg31k3p;
+extern hcrngMrg32k3aStream *streamsMrg32k3a;
+extern hcrngLfsr113Stream *streamsLfsr113;
+extern hcrngPhilox432Stream *streamsPhilox432;
+extern hcrngXorwowStream *streamsXorwow;
 
 hiprngStatus_t hipHCRNGStatusToHIPStatus(hcrngStatus hcStatus);
 

--- a/lib/src/hcc_detail/hiprng.cpp
+++ b/lib/src/hcc_detail/hiprng.cpp
@@ -30,6 +30,20 @@ THE SOFTWARE.
 extern "C" {
 #endif
 
+hcrngMrg31k3pStream *streams_bufferMrg31k3p = NULL;
+hcrngMrg32k3aStream *streams_bufferMrg32k3a = NULL;
+hcrngLfsr113Stream *streams_bufferLfsr113 = NULL;
+hcrngPhilox432Stream *streams_bufferPhilox432 = NULL;
+hcrngXorwowStream *streams_bufferXorwow = NULL;
+
+hcrngMrg31k3pStream *streamsMrg31k3p = NULL;
+hcrngMrg32k3aStream *streamsMrg32k3a = NULL;
+hcrngLfsr113Stream *streamsLfsr113 = NULL;
+hcrngPhilox432Stream *streamsPhilox432 = NULL;
+hcrngXorwowStream *streamsXorwow = NULL;
+
+
+
 hiprngStatus_t hipHCRNGStatusToHIPStatus(hcrngStatus hcStatus) {
   switch (hcStatus) {
     case HCRNG_SUCCESS:


### PR DESCRIPTION
Defining and initializing global variables in .h files causes the project that uses the hcRNG library to have multiple definition problems. 