### PR TITLE
Store declarations, not definitions inside header files.

### DIFF
--- a/lib/include/hcc_detail/hip_rng.h
+++ b/lib/include/hcc_detail/hip_rng.h
@@ -62,17 +62,17 @@ typedef mtgp32_kernel_params mtgp32_kernel_params_t;
 
 typedef void *hiprngGenerator_t;
 
-hcrngMrg31k3pStream *streams_bufferMrg31k3p = NULL;
-hcrngMrg32k3aStream *streams_bufferMrg32k3a = NULL;
-hcrngLfsr113Stream *streams_bufferLfsr113 = NULL;
-hcrngPhilox432Stream *streams_bufferPhilox432 = NULL;
-hcrngXorwowStream *streams_bufferXorwow = NULL;
+extern hcrngMrg31k3pStream *streams_bufferMrg31k3p;
+extern hcrngMrg32k3aStream *streams_bufferMrg32k3a;
+extern hcrngLfsr113Stream *streams_bufferLfsr113;
+extern hcrngPhilox432Stream *streams_bufferPhilox432;
+extern hcrngXorwowStream *streams_bufferXorwow;
 
-hcrngMrg31k3pStream *streamsMrg31k3p = NULL;
-hcrngMrg32k3aStream *streamsMrg32k3a = NULL;
-hcrngLfsr113Stream *streamsLfsr113 = NULL;
-hcrngPhilox432Stream *streamsPhilox432 = NULL;
-hcrngXorwowStream *streamsXorwow = NULL;
+extern hcrngMrg31k3pStream *streamsMrg31k3p;
+extern hcrngMrg32k3aStream *streamsMrg32k3a;
+extern hcrngLfsr113Stream *streamsLfsr113;
+extern hcrngPhilox432Stream *streamsPhilox432;
+extern hcrngXorwowStream *streamsXorwow;
 
 hiprngStatus_t hipHCRNGStatusToHIPStatus(hcrngStatus hcStatus);
 

--- a/lib/include/hcc_detail/hip_rng_kernel.h
+++ b/lib/include/hcc_detail/hip_rng_kernel.h
@@ -46,17 +46,6 @@ __host__ hiprngStatus_t hiprngMakeMTGP32KernelState (hiprngStateMtgp32_t* s, mtg
 //     Set up constant parameters for the mtgp32 generator. 
 __host__ hiprngStatus_t hiprngMakeMTGP32Constants ( const mtgp32_params_fast_t params[], mtgp32_kernel_params_t* p );
 
-
-//  Return a log-normally distributed float from an MTGP32 generator. 
-__device__ float hiprng_log_normal ( hiprngStateMtgp32_t* state, float  mean, float  stddev) {
-    return hcrng_log_normal(reinterpret_cast<hcrngStateMtgp32*>(state), mean, stddev);
-}
-
-//  Return a log-normally distributed double from an MTGP32 generator. 
-__device__ double hiprng_log_normal_double ( hiprngStateMtgp32_t* state, double  mean, double  stddev ) {
-    return hcrng_log_normal(reinterpret_cast<hcrngStateMtgp32*>(state), mean, stddev);
-}
-
 //  Return a log-normally distributed float from an MTGP32 generator.
 __device__ float hiprng_log_normal ( hiprngStateMtgp32_t* state, float  mean, float  stddev);
 

--- a/lib/include/hcc_detail/hip_rng_kernel.h
+++ b/lib/include/hcc_detail/hip_rng_kernel.h
@@ -57,30 +57,26 @@ __device__ double hiprng_log_normal_double ( hiprngStateMtgp32_t* state, double 
     return hcrng_log_normal(reinterpret_cast<hcrngStateMtgp32*>(state), mean, stddev);
 }
 
-//   Return a normally distributed float from a MTGP32 generator. 
-__device__ float hiprng_normal ( hiprngStateMtgp32_t* state ) {
-    return hcrng_normal(reinterpret_cast<hcrngStateMtgp32*>(state));
-}
+//  Return a log-normally distributed float from an MTGP32 generator.
+__device__ float hiprng_log_normal ( hiprngStateMtgp32_t* state, float  mean, float  stddev);
 
-//  Return a normally distributed double from an MTGP32 generator. 
-__device__ double hiprng_normal_double ( hiprngStateMtgp32_t* state) {
-    return hcrng_normal(reinterpret_cast<hcrngStateMtgp32*>(state));
-}
+//  Return a log-normally distributed double from an MTGP32 generator.
+__device__ double hiprng_log_normal_double ( hiprngStateMtgp32_t* state, double  mean, double  stddev );
 
-//   Return a uniformly distributed float from a MTGP32 generator. 
-__device__ float hiprng_uniform ( hiprngStateMtgp32_t* state ) {
-    return hcrng_uniform(reinterpret_cast<hcrngStateMtgp32*>(state));
-}
+//   Return a normally distributed float from a MTGP32 generator.
+__device__ float hiprng_normal ( hiprngStateMtgp32_t* state );
 
-//  Return a uniformly distributed double from an MTGP32 generator. 
-__device__ double hiprng_uniform_double ( hiprngStateMtgp32_t* state) {
-    return hcrng_uniform(reinterpret_cast<hcrngStateMtgp32*>(state));
-}
+//  Return a normally distributed double from an MTGP32 generator.
+__device__ double hiprng_normal_double ( hiprngStateMtgp32_t* state);
 
-//  Return a uniformly distributed double from an MTGP32 generator. 
-__device__ unsigned int hiprng ( hiprngStateMtgp32_t* state) {
-    return hcrng(reinterpret_cast<hcrngStateMtgp32*>(state));
-}
+//   Return a uniformly distributed float from a MTGP32 generator.
+__device__ float hiprng_uniform ( hiprngStateMtgp32_t* state );
+
+//  Return a uniformly distributed double from an MTGP32 generator.
+__device__ double hiprng_uniform_double ( hiprngStateMtgp32_t* state);
+
+//  Return a uniformly distributed double from an MTGP32 generator.
+__device__ unsigned int hiprng ( hiprngStateMtgp32_t* state);
 
 
 }

--- a/lib/src/hcc_detail/hip_rng_kernel.cpp
+++ b/lib/src/hcc_detail/hip_rng_kernel.cpp
@@ -52,7 +52,40 @@ __host__ hiprngStatus_t hiprngMakeMTGP32KernelState(hiprngStateMtgp32_t *s,
   return HIPRNG_STATUS_SUCCESS;
 }
 
+//  Return a log-normally distributed float from an MTGP32 generator.
+__device__ float hiprng_log_normal ( hiprngStateMtgp32_t* state, float  mean, float  stddev) {
+    return hcrng_log_normal(reinterpret_cast<hcrngStateMtgp32*>(state), mean, stddev);
+}
 
+//  Return a log-normally distributed double from an MTGP32 generator.
+__device__ double hiprng_log_normal_double ( hiprngStateMtgp32_t* state, double  mean, double  stddev ) {
+    return hcrng_log_normal(reinterpret_cast<hcrngStateMtgp32*>(state), mean, stddev);
+}
+
+//   Return a normally distributed float from a MTGP32 generator.
+__device__ float hiprng_normal ( hiprngStateMtgp32_t* state ) {
+    return hcrng_normal(reinterpret_cast<hcrngStateMtgp32*>(state));
+}
+
+//  Return a normally distributed double from an MTGP32 generator.
+__device__ double hiprng_normal_double ( hiprngStateMtgp32_t* state) {
+    return hcrng_normal(reinterpret_cast<hcrngStateMtgp32*>(state));
+}
+
+//   Return a uniformly distributed float from a MTGP32 generator.
+__device__ float hiprng_uniform ( hiprngStateMtgp32_t* state ) {
+    return hcrng_uniform(reinterpret_cast<hcrngStateMtgp32*>(state));
+}
+
+//  Return a uniformly distributed double from an MTGP32 generator.
+__device__ double hiprng_uniform_double ( hiprngStateMtgp32_t* state) {
+    return hcrng_uniform(reinterpret_cast<hcrngStateMtgp32*>(state));
+}
+
+//  Return a uniformly distributed double from an MTGP32 generator.
+__device__ unsigned int hiprng ( hiprngStateMtgp32_t* state) {
+    return hcrng(reinterpret_cast<hcrngStateMtgp32*>(state));
+}
 
 
 

--- a/lib/src/hcc_detail/hiprng.cpp
+++ b/lib/src/hcc_detail/hiprng.cpp
@@ -30,6 +30,18 @@ THE SOFTWARE.
 extern "C" {
 #endif
 
+hcrngMrg31k3pStream *streams_bufferMrg31k3p = NULL;
+hcrngMrg32k3aStream *streams_bufferMrg32k3a = NULL;
+hcrngLfsr113Stream *streams_bufferLfsr113 = NULL;
+hcrngPhilox432Stream *streams_bufferPhilox432 = NULL;
+hcrngXorwowStream *streams_bufferXorwow = NULL;
+
+hcrngMrg31k3pStream *streamsMrg31k3p = NULL;
+hcrngMrg32k3aStream *streamsMrg32k3a = NULL;
+hcrngLfsr113Stream *streamsLfsr113 = NULL;
+hcrngPhilox432Stream *streamsPhilox432 = NULL;
+hcrngXorwowStream *streamsXorwow = NULL;
+
 hiprngStatus_t hipHCRNGStatusToHIPStatus(hcrngStatus hcStatus) {
   switch (hcStatus) {
     case HCRNG_SUCCESS:


### PR DESCRIPTION
The header file hcRNG/lib/include/hcc_detail/hip_rng.h isn't written correctly. Generally, only declarations should be kept inside a header file, not definitions. 

These definitions are defined each time the header is included.

`hcrngMrg31k3pStream *streams_bufferMrg31k3p = NULL;
hcrngMrg32k3aStream *streams_bufferMrg32k3a = NULL;
hcrngLfsr113Stream *streams_bufferLfsr113 = NULL;
hcrngPhilox432Stream *streams_bufferPhilox432 = NULL;
hcrngXorwowStream *streams_bufferXorwow = NULL;

hcrngMrg31k3pStream *streamsMrg31k3p = NULL;
hcrngMrg32k3aStream *streamsMrg32k3a = NULL;
hcrngLfsr113Stream *streamsLfsr113 = NULL;
hcrngPhilox432Stream *streamsPhilox432 = NULL;
hcrngXorwowStream *streamsXorwow = NULL;`

**Rationale:**
When linking multiple object files that both include the header hip_rng.h, you will arrive with a multiple definition error. e.g. **"multiple definition of `streamsMrg32k3a'"** 